### PR TITLE
fix highlight issue, add treesitter

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -3,4 +3,5 @@ require "monroe.keymap"
 require "monroe.options"
 require "monroe.cmp"
 require "monroe.lsp"
+require "monroe.treesitter"
 

--- a/lua/monroe/keymap.lua
+++ b/lua/monroe/keymap.lua
@@ -32,7 +32,7 @@ keymap("n", "<A-o>", ":tabnew<CR>:Lex 30<CR>", opts)
 -- Resize with Arrows
 keymap("n", "<C-Up>", ":resize +2<cr>", opts)
 keymap("n", "<C-Down>", ":resize -2<cr>", opts)
-keymap("n", "<C-Left>", ":vertical resize +2<cr>", opts)    -- unfortunately 
+keymap("n", "<C-Left>", ":vertical resize +2<cr>", opts)    -- unfortunately
 keymap("n", "<C-Right>", ":vertical resize -2<cr>", opts)
 
 -- Move Text Up or Down

--- a/lua/monroe/lsp/handlers.lua
+++ b/lua/monroe/lsp/handlers.lua
@@ -21,7 +21,7 @@ M.setup = function()
       active = signs,
     },
     update_in_insert = true,
-    underline = true,
+    underline = false,
     severity_sort = true,
     float = {
       focusable = false,

--- a/lua/monroe/options.lua
+++ b/lua/monroe/options.lua
@@ -3,7 +3,7 @@ vim.opt.filetype = "on"                         -- make sure we are looking at f
 vim.opt.backspace = "indent,eol,start"          -- set backspacing behavior
 
 vim.opt.backup = false                          -- creates a backup file
-vim.opt.cmdheight = 2                           -- more space in the neovim command line for messages 
+vim.opt.cmdheight = 2                           -- more space in the neovim command line for messages
 vim.opt.fileencoding = "utf-8"                  -- the encoding written to a file
 vim.opt.hlsearch = true                         -- highlight all matches on previous search pattern
 vim.opt.ignorecase = true                       -- ignore case in search patterns
@@ -34,6 +34,6 @@ vim.opt.guifont = "Hack 10"                     -- the font used in graphical ne
 
 vim.cmd "colorscheme codemonkey"                  -- prefered console color scheme
 
-vim.cmd("highlight! ErrorMsg guibg=White guifg=Red")                    -- TODO: this doesn't seem to work
+-- vim.cmd("highlight! ErrorMsg guibg=White guifg=Red")                    -- TODO: this doesn't seem to work
 -- vim.cmd("highlight! CursorLine gui=underline ") -- TODO: this doesn't seem to work
-
+--

--- a/lua/monroe/plugins.lua
+++ b/lua/monroe/plugins.lua
@@ -33,5 +33,8 @@ Plug 'williamboman/nvim-lsp-installer'
 -- Telescope --
 Plug "nvim-telescope/telescope.nvim"
 
+-- Treesitter --
+Plug "nvim-treesitter/nvim-treesitter"
+Plug "p00f/nvim-ts-rainbow"
 
 vim.call('plug#end')

--- a/lua/monroe/treesitter.lua
+++ b/lua/monroe/treesitter.lua
@@ -1,0 +1,21 @@
+local status_ok, configs = pcall(require, "nvim-treesitter.configs")
+if not status_ok then
+    return
+end
+
+configs.setup {
+    ensure_installed = "maintained",
+    sync_install = false,
+    ignore_install = { "" },
+    highlight = {
+        enable = true,
+        disable = { "" },
+        additional_vim_regex_highlighting = true,
+    },
+    indent = {enable = true, disable = { "yaml" } },
+    rainbow = {
+        enable = true,
+        extended_mode = true,
+        max_file_lines = nil,
+    }
+}


### PR DESCRIPTION
treesitter is a syntax highlighting plugin that does a bit better than
standard

also found the issue that was causing words under the cursor to get
highlighted